### PR TITLE
Add RustChain - Proof-of-Antiquity decentralized blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 * [Retroshare](https://retroshare.cc): Encrypted connections between you and your friends to create a network of computers, and provides various distributed services on top of it: forums, channels, chat, mail...
 * [Ricochet](https://github.com/blueprint-freespeech/ricochet-refresh): Different approach to instant messaging that doesn’t trust anyone in protecting your privacy. It uses the Tor network.
 * [Roll-Call](https://rollcall.audio): Free and reliable audio calls for everyone w/ browser P2P.
+* [RustChain](https://github.com/Scottcjn/Rustchain): Proof-of-Antiquity blockchain where vintage hardware (PowerPC G4/G5, Pentium 4) earns higher mining rewards through 6-point hardware fingerprint attestation. Decentralized consensus via round-robin 1-CPU-1-Vote, Ed25519 signatures, and Ergo blockchain anchoring.
 * [SecuShare](https://secushare.org): A research project. Consider that it basically consists of a new Internet stack combined with a full-fledged distributed scalability alternative to cloud technology. Source code: https://gnunet.org/git/gnunet.git
 * [Session](https://getsession.org): Session is an end-to-end encrypted messenger that minimises sensitive metadata, designed and built for people who want absolute privacy and freedom from any form of surveillance.
 * [ShareDrop ☠️](https://github.com/cowbell/sharedrop): Clone of Apple AirDrop service. Allows transferring files directly between devices, without having to upload them to any server first.


### PR DESCRIPTION
## Summary

Adds [RustChain](https://github.com/Scottcjn/Rustchain) to the Applications section in alphabetical order.

RustChain is a decentralized blockchain that uses a novel **Proof-of-Antiquity** consensus mechanism. It rewards participants running real vintage hardware (PowerPC G4/G5, Pentium 4, etc.) with higher mining multipliers, verified through 6-point hardware fingerprinting that prevents VM spoofing.

**Why it fits this list:**
- Fully decentralized peer-to-peer consensus (RIP-200 round-robin 1-CPU-1-Vote)
- No central authority -- any physical hardware can participate
- Anti-emulation checks prevent centralized VM farm attacks
- Cross-chain anchoring to Ergo blockchain for immutable audit trails
- Ed25519 cryptographic signatures and BIP39 mnemonic wallets

Entry placed alphabetically between Roll-Call and SecuShare, following the `* [Name](url): Description` format.